### PR TITLE
Issue-1: Linux support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -212,4 +212,7 @@ An up-to-date list of known issues is available [here](History.md).
 Please refer to the issues tab! :)
 
 
-
+# Linux
+```
+sudo apt-get install libbluetooth-dev
+```

--- a/examples/example_linux.py
+++ b/examples/example_linux.py
@@ -1,0 +1,111 @@
+import os
+
+from tapsdk import TapSDK, TapInputMode
+from tapsdk.models import AirGestures
+
+import asyncio
+import logging
+from bleak import _logger as logger
+
+
+def notification_handler(sender, data):
+    """Simple notification handler which prints the data received."""
+    print("{0}: {1}".format(sender, data))
+
+
+def OnMouseModeChange(identifier, mouse_mode):
+    print(identifier + " changed to mode " + str(mouse_mode))
+
+
+def OnTapped(identifier, tapcode):
+    print(identifier + " tapped " + str(tapcode))
+
+
+def OnGesture(identifier, gesture):
+    print(identifier + " gesture " + str(AirGestures(gesture)))
+
+
+def OnTapConnected(self, identifier, name, fw):
+    print(identifier + " Tap: " + str(name), " FW Version: ", fw)
+
+
+def OnTapDisconnected(self, identifier):
+    print(identifier + " Tap: " + identifier + " disconnected")
+
+
+def OnMoused(identifier, vx, vy, isMouse):
+    print(identifier + " mouse movement: %d, %d, %d" % (vx, vy, isMouse))
+
+
+def OnRawData(identifier, packets):
+    OnRawData.cnt += 1
+    if OnRawData.cnt % 20:
+        return
+
+    for imu_mgs in list(filter(lambda m: m["type"] == "accl", packets))[:1]:
+        payload = [("{:>2}".format(int(p / 10))) for p in imu_mgs["payload"]]
+        logger.warning("{} raw imu : {}".format(identifier, payload))
+
+
+    """
+    for m in packets:
+        if m["type"] == "imu":
+            # print("imu")
+            OnRawData.imu_cnt += 1
+            if OnRawData.imu_cnt == 208:
+                OnRawData.imu_cnt = 0
+                # print("imu, " + str(time.time()) + ", " + str(m["payload"]))
+        if m["type"] == "accl":
+            # print("accl")
+            OnRawData.accl_cnt += 1
+            if OnRawData.accl_cnt == 200:
+                OnRawData.accl_cnt = 0
+                print("accl, " + str(time.time()) + ", " + str(m["payload"]))
+
+"""
+
+
+OnRawData.imu_cnt = 0
+OnRawData.accl_cnt = 0
+OnRawData.cnt = 0
+
+
+async def run(loop=None, debug=False):
+    if debug:
+        import sys
+
+        loop.set_debug(True)
+        h = logging.StreamHandler(sys.stdout)
+        h.setLevel(logging.WARNING)
+        logger.addHandler(h)
+
+    sdk = TapSDK(None, loop)
+    if not await sdk.client.connect_retrieved():
+        logger.error("Failed to connect the the Device.")
+        return
+
+    logger.info("Connected to {}".format(sdk.client.address))
+
+    vibrations = [10000]
+    logger.info("sending vibration sequence: {}".format(vibrations))
+    await sdk.send_vibration_sequence(vibrations)
+
+    await sdk.register_air_gesture_events(OnGesture)
+    await sdk.register_tap_events(OnTapped)
+    await sdk.register_raw_data_events(OnRawData)
+    await sdk.register_mouse_events(OnMoused)
+    await sdk.register_air_gesture_state_events(OnMouseModeChange)
+
+    # logger.info("Changing to text mode")
+    await sdk.set_input_mode(TapInputMode("text"))
+    # await asyncio.sleep(30))
+    logger.info("Changing to raw mode")
+    await sdk.set_input_mode(TapInputMode("raw", sensitivity=[1023, 1023, 1023]))
+
+    await asyncio.sleep(2 * 60)
+    await sdk.send_vibration_sequence(vibrations)
+
+
+if __name__ == "__main__":
+    event_loop = asyncio.get_event_loop()
+    event_loop.run_until_complete(run(event_loop, True))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+bleak
+setuptools

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,9 @@ EMAIL = "support@tapwithus.com"
 AUTHOR = "Tap systems Inc."
 
 REQUIRED = [
-    # macOS reqs
+    # linux reqs
+    'bleak==0.6.4;platform_system=="Linux"',
+     # macOS reqs
     'bleak==0.5.1;platform_system=="Darwin"',
     # Windows reqs
     'pythonnet;platform_system=="Windows"'

--- a/tapsdk/__init__.py
+++ b/tapsdk/__init__.py
@@ -9,3 +9,8 @@ if this_platform == "Windows":
 elif this_platform == "Darwin":
     from tapsdk.backends.macos.TapSDK import TapMacSDK as TapSDK 
     from tapsdk.backends.macos.inputmodes import TapInputMode
+elif this_platform == "Linux":
+    from tapsdk.backends.linux.TapSDK import TapLinuxSDK as TapSDK
+    from tapsdk.backends.linux.inputmodes import TapInputMode
+else:
+   raise ValueError("Value for platfrom is unknown: {}".format(this_platform))

--- a/tapsdk/backends/linux/TapSDK.py
+++ b/tapsdk/backends/linux/TapSDK.py
@@ -1,43 +1,43 @@
-import logging
-import asyncio 
+import asyncio
 from asyncio.events import AbstractEventLoop
-import platform
-
-import bluetooth
-
+from subprocess import Popen, PIPE
 from typing import Callable
 
-from bleak import BleakClient
+from bleak import BleakClient, discover
 from bleak import _logger as logger
-from bleak import BleakScanner
-from subprocess import Popen, PIPE
+from bleak.backends.client import BaseBleakClient
 
+from tapsdk import parsers
+from .inputmodes import TapInputMode
 from ...TapSDK import TapSDKBase
 from ...models import TapUUID
-from .inputmodes import TapInputMode
 from ...models.enumerations import MouseModes
-from tapsdk import parsers
+
 
 class TapClient(BleakClient):
     def __init__(self, address=None, loop=None, **kwargs):
         super().__init__(address, loop=loop, **kwargs)
-    
-    async def connect_retrieved(self, **kwargs) -> bool:
-        async with BleakClient(self.address, loop=self.loop) as client:
-            connected = await client.is_connected()
-            if connected:
-                logger.info("Connected to {0}".format(self.address))
-            else:
-                logger.error("Failed to connect to {0}".format(self.address))
-            return connected
 
-    async def __debug(self): 
-        for service in  client.services:
+    def set_disconnected_callback(self, callback: Callable[[BaseBleakClient], None], **kwargs) -> None:
+        pass
+
+    async def connect_retrieved(self, **kwargs) -> bool:
+        await self.connect()
+        connected = await self.is_connected()
+        if connected:
+            logger.info("Connected to {0}".format(self.address))
+            await self.__debug()
+        else:
+            logger.error("Failed to connect to {0}".format(self.address))
+        return connected
+
+    async def __debug(self):
+        for service in self.services:
             logger.info("[service] {}: {}".format(service.uuid, service.description))
             for char in service.characteristics:
                 if "read" in char.properties:
                     try:
-                        value =  bytes(await clien.read_gatt_char(char.uuid))
+                        value = bytes(await self.read_gatt_char(char.uuid))
                     except Exception as e:
                         value = str(e).encode
                 else:
@@ -46,23 +46,25 @@ class TapClient(BleakClient):
                 logger.info(
                     "\t[Characteristic] {0}: (Handle: {1}) ({2}) | Name: {3}, Value: {4} ".format(
                         char.uuid,
-                        "<handle geos here>",  #char.handle,
+                        "<handle geos here>",  # char.handle,
                         ",".join(char.properties),
                         char.description,
                         value,
                     )
                 )
 
+
 def is_tap_device(device):
     return True or len(device.metadata) > 0
+
 
 class TapLinuxSDK(TapSDKBase):
     def __init__(self, address=None, loop: AbstractEventLoop = None):
         super(TapLinuxSDK, self).__init__()
+        self.address = address if address else self.get_mac_addr()
+        self.client = TapClient(self.address)
         self.loop = loop
-        self.address = None
-        self.address = self.get_mac_addr()
-        self.manager = TapClient(address=self.address,loop=loop)
+        self.address = address
         self.mouse_event_cb = None
         self.tap_event_cb = None
         self.air_gesture_event_cb = None
@@ -70,31 +72,31 @@ class TapLinuxSDK(TapSDKBase):
         self.air_gesture_state_event_cb = None
         self.input_mode_refresh = InputModeAutoRefresh(self._refresh_input_mode, timeout=10)
         self.mouse_mode = MouseModes.STDBY
-        self.input_mode = TapInputMode("text")
+        self.input_mode = TapInputMode("raw")
 
     async def register_tap_events(self, cb: Callable):
         if cb:
-            await self.manager.start_notify(TapUUID.tap_data_characteristic.lower(), self.on_tapped)
+            await self.client.start_notify(TapUUID.tap_data_characteristic.lower(), self.on_tapped)
             self.tap_event_cb = cb
 
     async def register_mouse_events(self, cb: Callable):
         if cb:
-            await self.manager.start_notify(TapUUID.mouse_data_characteristic.lower(), self.on_moused)
+            await self.client.start_notify(TapUUID.mouse_data_characteristic.lower(), self.on_moused)
             self.mouse_event_cb = cb
-    
+
     async def register_air_gesture_events(self, cb: Callable):
         if cb:
-            await self.manager.start_notify(TapUUID.air_gesture_data_characteristic.lower(), self.on_air_gesture)
+            await self.client.start_notify(TapUUID.air_gesture_data_characteristic.lower(), self.on_air_gesture)
             self.air_gesture_event_cb = cb
-    
+
     async def register_air_gesture_state_events(self, cb: Callable):
         if cb:
-            await self.manager.start_notify(TapUUID.air_gesture_data_characteristic.lower(), self.on_air_gesture)
+            await self.client.start_notify(TapUUID.air_gesture_data_characteristic.lower(), self.on_air_gesture)
             self.air_gesture_state_event_cb = cb
 
     async def register_raw_data_events(self, cb: Callable):
         if cb:
-            await self.manager.start_notify(TapUUID.raw_sensors_characteristic.lower(), self.on_raw_data)
+            await self.client.start_notify(TapUUID.raw_sensors_characteristic.lower(), self.on_raw_data)
             self.raw_data_event_cb = cb
 
     async def register_connection_events(self, cb: Callable):
@@ -104,75 +106,78 @@ class TapLinuxSDK(TapSDKBase):
         pass
 
     def get_mac_addr(self) -> str:
-        if not self.address:
-            try:
-                with Popen(["bt-device", "--list"], stdout=PIPE, text=True) as btdevice_process:
-                    exit_code = btdevice_process.wait()
-                    if exit_code:
-                        raise ConnectionError("Failed to find any TAP decive")
-                    connected_bt_devices = btdevice_process.stdout.read().splitlines();
-                    tap_devices = list(filter(lambda line: line.startswith("Tap_"), connected_bt_devices))
-                    for d in tap_devices:
-                        logger.info("Found tap device: {}".format(d))
-                    if len(tap_devices) > 1:
-                        raise ValueError("Found more than 1 Tap device. Set the MAC address of the device you want to connect to and try again.")
-                    if len(tap_devices) == 0:
-                        raise ValueError("No Tap device was found. Make sure the device is connected and its human readable name starts with Tap_.")
-                    device_decs = tap_devices[0]
-                    tap_mac_address = device_decs[-18:-1] # only the mac_address part of the description.
-                    return tap_mac_address
-            except Exception as e:
-                logger.error("Failed to find any TAP device: {}".format(e))
-                raise e
- 
+        try:
+            with Popen(["bt-device", "--list"], stdout=PIPE, text=True) as btdevice_process:
+                exit_code = btdevice_process.wait()
+                if exit_code:
+                    raise ConnectionError("Failed to find any TAP decive")
+                connected_bt_devices = btdevice_process.stdout.read().splitlines();
+                tap_devices = list(filter(lambda line: line.startswith("Tap_"), connected_bt_devices))
+                for d in tap_devices:
+                    logger.info("Found tap device: {}".format(d))
+                if len(tap_devices) > 1:
+                    raise ValueError(
+                        "Found more than 1 Tap device. Set the MAC address of the device you want to connect to "
+                        "and try again.")
+                if len(tap_devices) == 0:
+                    raise ValueError(
+                        "No Tap device was found. Make sure the device is connected and its human readable name "
+                        "starts with Tap_.")
+                device_decs = tap_devices[0]
+                tap_mac_address = device_decs[-18:-1]  # only the mac_address part of the description.
+                return tap_mac_address
+        except Exception as e:
+            logger.error("Failed to find any TAP device: {}".format(e))
+            raise e
+
     def on_moused(self, identifier, data):
         if self.mouse_event_cb:
             args = parsers.mouse_data_msg(data)
             self.mouse_event_cb(identifier, *args)
-    
+
     def on_tapped(self, identifier, data):
         args = parsers.tap_data_msg(data)
         if self.mouse_mode == MouseModes.AIR_MOUSE:
             tapcode = args[0]
             if tapcode in [2, 4]:
-                self.on_air_gesture(identifier, [tapcode+10])
+                self.on_air_gesture(identifier, [tapcode + 10])
         elif self.tap_event_cb:
             self.tap_event_cb(identifier, *args)
-    
+
     def on_raw_data(self, identifier, data):
         if self.raw_data_event_cb:
             args = parsers.raw_data_msg(data)
             self.raw_data_event_cb(identifier, args)
 
     def on_air_gesture(self, identifier, data):
-        if data[0] == 0x14: # mouse mode event
+        if data[0] == 0x14:  # mouse mode event
             self.mouse_mode = MouseModes(data[1])
             if self.air_gesture_state_event_cb:
                 self.air_gesture_state_event_cb(identifier, self.mouse_mode == MouseModes.AIR_MOUSE)
         elif self.air_gesture_event_cb:
             args = parsers.air_gesture_data_msg(data)
             self.air_gesture_event_cb(identifier, *args)
-    
-    async def send_vibration_sequence(self, sequence:list, identifier=None):
+
+    async def send_vibration_sequence(self, sequence: list, identifier=None):
         if len(sequence) > 18:
             sequence = sequence[:18]
         for i, d in enumerate(sequence):
-            sequence[i] = max(0,min(255,d//10))
- 
-        write_value = bytearray([0x0,0x2] + sequence)
-        await self.manager.write_gatt_char(TapUUID.ui_cmd_characteristic.lower() , write_value)
+            sequence[i] = max(0, min(255, d // 10))
 
-    async def set_input_mode(self, input_mode:TapInputMode, identifier=None):
-        if  (input_mode.mode == "raw" and 
-            self.input_mode.mode == "raw" and 
-            self.input_mode.get_command() != input_mode.get_command()):
+        write_value = bytearray([0x0, 0x2] + sequence)
+        await self.client.write_gatt_char(TapUUID.ui_cmd_characteristic.lower(), write_value)
+
+    async def set_input_mode(self, input_mode: TapInputMode, identifier=None):
+        if (input_mode.mode == "raw" and
+                self.input_mode.mode == "raw" and
+                self.input_mode.get_command() != input_mode.get_command()):
             logger.warning("Can't change \"raw\" sensitivities while in \"raw\"")
             return
 
         self.input_mode = input_mode
         write_value = input_mode.get_command()
 
-        if self.input_mode_refresh.is_running == False:
+        if not self.input_mode_refresh.is_running:
             await self.input_mode_refresh.start()
 
         await self._write_input_mode(write_value)
@@ -180,34 +185,34 @@ class TapLinuxSDK(TapSDKBase):
     async def _refresh_input_mode(self):
         await self.set_input_mode(self.input_mode)
         logger.debug("Input Mode Refreshed: " + self.input_mode.get_name())
-        
+
     async def _write_input_mode(self, value):
-        # TODO: uncomment me
-        # await self.manager.write_gatt_char(TapUUID.tap_mode_characteristic.lower(), value)
+        await self.client.write_gatt_char(TapUUID.tap_mode_characteristic.lower(), value)
         pass
 
     async def list_connected_taps(self):
         devices = await discover(loop=self.loop)
         return devices
-    
+
     async def run(self):
-        await self.manager.connect_retrieved()
+        await self.connect_retrieved()
+
 
 class InputModeAutoRefresh:
-    def __init__(self, set_function: Callable, timeout:int=10):
+    def __init__(self, set_function: Callable, timeout: int = 10):
         self.set_function = set_function
         self.is_running = False
         self.timeout = timeout
         self.wd_task = None
 
     async def start(self):
-        if self.is_running == False:
+        if not self.is_running:
             self.wd_task = asyncio.create_task(self.periodic())
             self.is_running = True
             logger.debug("Input Mode Auto Refresh Started")
-    
+
     async def stop(self):
-        if self.is_running == True:
+        if self.is_running:
             self.wd_task.cancel()
             self.is_running = False
             logger.debug("Input Mode Auto Refresh Stopped")

--- a/tapsdk/backends/linux/TapSDK.py
+++ b/tapsdk/backends/linux/TapSDK.py
@@ -1,0 +1,218 @@
+import logging
+import asyncio 
+from asyncio.events import AbstractEventLoop
+import platform
+
+import bluetooth
+
+from typing import Callable
+
+from bleak import BleakClient
+from bleak import _logger as logger
+from bleak import BleakScanner
+from subprocess import Popen, PIPE
+
+from ...TapSDK import TapSDKBase
+from ...models import TapUUID
+from .inputmodes import TapInputMode
+from ...models.enumerations import MouseModes
+from tapsdk import parsers
+
+class TapClient(BleakClient):
+    def __init__(self, address=None, loop=None, **kwargs):
+        super().__init__(address, loop=loop, **kwargs)
+    
+    async def connect_retrieved(self, **kwargs) -> bool:
+        async with BleakClient(self.address, loop=self.loop) as client:
+            connected = await client.is_connected()
+            if connected:
+                logger.info("Connected to {0}".format(self.address))
+            else:
+                logger.error("Failed to connect to {0}".format(self.address))
+            return connected
+
+    async def __debug(self): 
+        for service in  client.services:
+            logger.info("[service] {}: {}".format(service.uuid, service.description))
+            for char in service.characteristics:
+                if "read" in char.properties:
+                    try:
+                        value =  bytes(await clien.read_gatt_char(char.uuid))
+                    except Exception as e:
+                        value = str(e).encode
+                else:
+                    value = None
+                # if value:
+                logger.info(
+                    "\t[Characteristic] {0}: (Handle: {1}) ({2}) | Name: {3}, Value: {4} ".format(
+                        char.uuid,
+                        "<handle geos here>",  #char.handle,
+                        ",".join(char.properties),
+                        char.description,
+                        value,
+                    )
+                )
+
+def is_tap_device(device):
+    return True or len(device.metadata) > 0
+
+class TapLinuxSDK(TapSDKBase):
+    def __init__(self, address=None, loop: AbstractEventLoop = None):
+        super(TapLinuxSDK, self).__init__()
+        self.loop = loop
+        self.address = None
+        self.address = self.get_mac_addr()
+        self.manager = TapClient(address=self.address,loop=loop)
+        self.mouse_event_cb = None
+        self.tap_event_cb = None
+        self.air_gesture_event_cb = None
+        self.raw_data_event_cb = None
+        self.air_gesture_state_event_cb = None
+        self.input_mode_refresh = InputModeAutoRefresh(self._refresh_input_mode, timeout=10)
+        self.mouse_mode = MouseModes.STDBY
+        self.input_mode = TapInputMode("text")
+
+    async def register_tap_events(self, cb: Callable):
+        if cb:
+            await self.manager.start_notify(TapUUID.tap_data_characteristic.lower(), self.on_tapped)
+            self.tap_event_cb = cb
+
+    async def register_mouse_events(self, cb: Callable):
+        if cb:
+            await self.manager.start_notify(TapUUID.mouse_data_characteristic.lower(), self.on_moused)
+            self.mouse_event_cb = cb
+    
+    async def register_air_gesture_events(self, cb: Callable):
+        if cb:
+            await self.manager.start_notify(TapUUID.air_gesture_data_characteristic.lower(), self.on_air_gesture)
+            self.air_gesture_event_cb = cb
+    
+    async def register_air_gesture_state_events(self, cb: Callable):
+        if cb:
+            await self.manager.start_notify(TapUUID.air_gesture_data_characteristic.lower(), self.on_air_gesture)
+            self.air_gesture_state_event_cb = cb
+
+    async def register_raw_data_events(self, cb: Callable):
+        if cb:
+            await self.manager.start_notify(TapUUID.raw_sensors_characteristic.lower(), self.on_raw_data)
+            self.raw_data_event_cb = cb
+
+    async def register_connection_events(self, cb: Callable):
+        pass
+
+    async def register_disconnection_events(self, cb: Callable):
+        pass
+
+    def get_mac_addr(self) -> str:
+        if not self.address:
+            try:
+                with Popen(["bt-device", "--list"], stdout=PIPE, text=True) as btdevice_process:
+                    exit_code = btdevice_process.wait()
+                    if exit_code:
+                        raise ConnectionError("Failed to find any TAP decive")
+                    connected_bt_devices = btdevice_process.stdout.read().splitlines();
+                    tap_devices = list(filter(lambda line: line.startswith("Tap_"), connected_bt_devices))
+                    for d in tap_devices:
+                        logger.info("Found tap device: {}".format(d))
+                    if len(tap_devices) > 1:
+                        raise ValueError("Found more than 1 Tap device. Set the MAC address of the device you want to connect to and try again.")
+                    if len(tap_devices) == 0:
+                        raise ValueError("No Tap device was found. Make sure the device is connected and its human readable name starts with Tap_.")
+                    device_decs = tap_devices[0]
+                    tap_mac_address = device_decs[-18:-1] # only the mac_address part of the description.
+                    return tap_mac_address
+            except Exception as e:
+                logger.error("Failed to find any TAP device: {}".format(e))
+                raise e
+ 
+    def on_moused(self, identifier, data):
+        if self.mouse_event_cb:
+            args = parsers.mouse_data_msg(data)
+            self.mouse_event_cb(identifier, *args)
+    
+    def on_tapped(self, identifier, data):
+        args = parsers.tap_data_msg(data)
+        if self.mouse_mode == MouseModes.AIR_MOUSE:
+            tapcode = args[0]
+            if tapcode in [2, 4]:
+                self.on_air_gesture(identifier, [tapcode+10])
+        elif self.tap_event_cb:
+            self.tap_event_cb(identifier, *args)
+    
+    def on_raw_data(self, identifier, data):
+        if self.raw_data_event_cb:
+            args = parsers.raw_data_msg(data)
+            self.raw_data_event_cb(identifier, args)
+
+    def on_air_gesture(self, identifier, data):
+        if data[0] == 0x14: # mouse mode event
+            self.mouse_mode = MouseModes(data[1])
+            if self.air_gesture_state_event_cb:
+                self.air_gesture_state_event_cb(identifier, self.mouse_mode == MouseModes.AIR_MOUSE)
+        elif self.air_gesture_event_cb:
+            args = parsers.air_gesture_data_msg(data)
+            self.air_gesture_event_cb(identifier, *args)
+    
+    async def send_vibration_sequence(self, sequence:list, identifier=None):
+        if len(sequence) > 18:
+            sequence = sequence[:18]
+        for i, d in enumerate(sequence):
+            sequence[i] = max(0,min(255,d//10))
+ 
+        write_value = bytearray([0x0,0x2] + sequence)
+        await self.manager.write_gatt_char(TapUUID.ui_cmd_characteristic.lower() , write_value)
+
+    async def set_input_mode(self, input_mode:TapInputMode, identifier=None):
+        if  (input_mode.mode == "raw" and 
+            self.input_mode.mode == "raw" and 
+            self.input_mode.get_command() != input_mode.get_command()):
+            logger.warning("Can't change \"raw\" sensitivities while in \"raw\"")
+            return
+
+        self.input_mode = input_mode
+        write_value = input_mode.get_command()
+
+        if self.input_mode_refresh.is_running == False:
+            await self.input_mode_refresh.start()
+
+        await self._write_input_mode(write_value)
+
+    async def _refresh_input_mode(self):
+        await self.set_input_mode(self.input_mode)
+        logger.debug("Input Mode Refreshed: " + self.input_mode.get_name())
+        
+    async def _write_input_mode(self, value):
+        # TODO: uncomment me
+        # await self.manager.write_gatt_char(TapUUID.tap_mode_characteristic.lower(), value)
+        pass
+
+    async def list_connected_taps(self):
+        devices = await discover(loop=self.loop)
+        return devices
+    
+    async def run(self):
+        await self.manager.connect_retrieved()
+
+class InputModeAutoRefresh:
+    def __init__(self, set_function: Callable, timeout:int=10):
+        self.set_function = set_function
+        self.is_running = False
+        self.timeout = timeout
+        self.wd_task = None
+
+    async def start(self):
+        if self.is_running == False:
+            self.wd_task = asyncio.create_task(self.periodic())
+            self.is_running = True
+            logger.debug("Input Mode Auto Refresh Started")
+    
+    async def stop(self):
+        if self.is_running == True:
+            self.wd_task.cancel()
+            self.is_running = False
+            logger.debug("Input Mode Auto Refresh Stopped")
+
+    async def periodic(self):
+        while True:
+            await self.set_function()
+            await asyncio.sleep(self.timeout)

--- a/tapsdk/backends/linux/inputmodes.py
+++ b/tapsdk/backends/linux/inputmodes.py
@@ -1,0 +1,34 @@
+import logging
+
+class TapInputMode:
+    def __init__(self, mode, sensitivity:list=[0,0,0]):
+        self._modes = {
+                "text" : {"name": "Text Mode", "code": bytearray([0x3,0xc,0x0,0x0])},
+                "controller" : {"name": "Controller Mode", "code": bytearray([0x3,0xc,0x0,0x1])},
+                "controller_text" : {"name": "Controller and Text Mode", "code": bytearray([0x3,0xc,0x0,0x3])},
+                "raw" : {"name": "Raw sensors Mode", "code": bytearray([0x3,0xc,0x0,0xa])}
+                }
+        self.sensitivity = sensitivity
+        if mode in self._modes.keys():
+            self.mode = mode
+            if mode == "raw":
+                self._register_sensitivity(sensitivity)
+        else:
+            logging.warning("Invalid mode \"%s\". Set to \"text\"" % mode)
+            self.mode = "text"
+
+
+    def _register_sensitivity(self, sensitivity):
+        if isinstance(sensitivity, list) and len(sensitivity) == 3:
+            sensitivity[0] = max(0, min(4,sensitivity[0])) # fingers accelerometers
+            sensitivity[1] = max(0, min(5,sensitivity[1])) # imu gyro
+            sensitivity[2] = max(0, min(4,sensitivity[2])) # imu accelerometer
+            self.sensitivity = sensitivity
+            self._modes["raw"]["code"] =  self._modes["raw"]["code"][:4] + bytearray(sensitivity)
+
+    def get_command(self):
+        return self._modes[self.mode]["code"]
+
+    def get_name(self):
+        return self._modes[self.mode]["name"]
+


### PR DESCRIPTION
[WIP] TAP LinuxSDK

The first pass at making linux bluetooth system connect and talk to TAP.

This Linux SDK, like the macOS SDK, uses bleak under the hood. Most of the Linux SDK is copy/paste from the macOS SDK.
The version of the bleak framework in the Linux SDK (v0.6.4) is slightly newer than the macOS SDK (v0.5.1), but I don't see any reason why they cannot be brought in sync.

# TODO Items
- If the MAC address of the TAP devices is not provided, the Linux SDK uses `bt-device`to discover the TAP device. The Linux SDK should discover the device only with python APIs and by the devices's service UUID.
- ~~The Linux SDK assumes there is only one TAP device.~~ I created a new issue to track it: #4
- Rebase this PR on top of #2
