### PR TITLE
Unregister events with .Net backend

### DIFF
--- a/tapsdk/backends/dotnet/TapSDK.py
+++ b/tapsdk/backends/dotnet/TapSDK.py
@@ -6,6 +6,7 @@ import System
 clr.AddReference(r"tapsdk/backends/dotnet/TAPWin")
 from TAPWin import TAPManager
 from TAPWin import TAPManagerLog
+from TAPWin import TAPManagerLogEvent
 from TAPWin import TAPInputMode
 from TAPWin import RawSensorSensitivity
 from TAPWin import TAPAirGesture
@@ -78,7 +79,7 @@ class TapWindowsSDK(TapSDKBase):
         self.unregister_event(TAPManagerLog.Instance.OnLineLogged, listener)
 
     def set_input_mode(self, mode:TapInputMode, tap_identifier=""):
-        print("input mode: " + mode.get_name())
+        TAPManagerLog.Instance.Log(TAPManagerLogEvent.Info, "input mode: " + mode.get_name(), __file__, __name__)
         TAPManager.Instance.SetTapInputMode(mode.get_object(), tap_identifier)
 
     def set_default_input_mode(self, mode, identifier=""):

--- a/tapsdk/backends/dotnet/TapSDK.py
+++ b/tapsdk/backends/dotnet/TapSDK.py
@@ -15,35 +15,69 @@ from TAPWin import RawSensorData
 class TapWindowsSDK(TapSDKBase):
     def __init__(self, *args):
         super().__init__()
-        TAPManagerLog.Instance.OnLineLogged += print
+        self.show_logs()
 
     def register_tap_events(self, listener=None):
         if listener is not None:
             TAPManager.Instance.OnTapped += listener
 
+    def unregister_tap_events(self, listener=None):
+        if listener is not None:
+            TAPManager.Instance.OnTapped -= listener
+
     def register_mouse_events(self, listener=None):
         if listener is not None:
             TAPManager.Instance.OnMoused += listener
+
+    def unregister_mouse_events(self, listener=None):
+        if listener is not None:
+            TAPManager.Instance.OnMoused -= listener
 
     def register_connection_events(self, listener=None):
         if listener is not None:
             TAPManager.Instance.OnTapConnected += listener
 
+    def unregister_connection_events(self, listener=None):
+        if listener is not None:
+            TAPManager.Instance.OnTapConnected -= listener
+
     def register_disconnection_events(self, listener=None):
         if listener is not None:
             TAPManager.Instance.OnTapDisconnected += listener
+
+    def unregister_disconnection_events(self, listener=None):
+        if listener is not None:
+            TAPManager.Instance.OnTapDisconnected -= listener
 
     def register_raw_data_events(self, listener=None):
         if listener is not None:
             TAPManager.Instance.OnRawSensorDataReceieved += listener
 
+    def unregister_raw_data_events(self, listener=None):
+        if listener is not None:
+            TAPManager.Instance.OnRawSensorDataReceieved -= listener
+
     def register_air_gesture_events(self, listener=None):
         if listener is not None:
             TAPManager.Instance.OnAirGestured += listener
 
+    def unregister_air_gesture_events(self, listener=None):
+        if listener is not None:
+            TAPManager.Instance.OnAirGestured -= listener
+
     def register_air_gesture_state_events(self, listener=None):
         if listener is not None:
             TAPManager.Instance.OnChangedAirGestureState += listener
+
+    def unregister_air_gesture_state_events(self, listener=None):
+        if listener is not None:
+            TAPManager.Instance.OnChangedAirGestureState -= listener
+
+    def show_logs(self):
+        TAPManagerLog.Instance.OnLineLogged += print
+
+    def suppress_logs(self):
+        TAPManagerLog.Instance.OnLineLogged -= print
 
     def set_input_mode(self, mode:TapInputMode, tap_identifier=""):
         print("input mode: " + mode.get_name())
@@ -63,6 +97,3 @@ class TapWindowsSDK(TapSDKBase):
     def run(self):
         self.set_default_input_mode("controller")
         TAPManager.Instance.Start()
-
-
-

--- a/tapsdk/backends/dotnet/TapSDK.py
+++ b/tapsdk/backends/dotnet/TapSDK.py
@@ -13,71 +13,69 @@ from TAPWin import RawSensorData
 
 
 class TapWindowsSDK(TapSDKBase):
+
     def __init__(self, *args):
         super().__init__()
-        self.show_logs()
+        self.register_log_events()
+
+    def register_event(self, event_handler, listener=None):
+        if listener is not None:
+            event_handler += listener
+
+    def unregister_event(self, event_handler, listener=None):
+        if listener is not None:
+            try:
+                event_handler -= listener
+            except ValueError:
+                pass
 
     def register_tap_events(self, listener=None):
-        if listener is not None:
-            TAPManager.Instance.OnTapped += listener
+        self.register_event(TAPManager.Instance.OnTapped, listener)
 
     def unregister_tap_events(self, listener=None):
-        if listener is not None:
-            TAPManager.Instance.OnTapped -= listener
+        self.unregister_event(TAPManager.Instance.OnTapped, listener)
 
     def register_mouse_events(self, listener=None):
-        if listener is not None:
-            TAPManager.Instance.OnMoused += listener
+        self.register_event(TAPManager.Instance.OnMoused, listener)
 
     def unregister_mouse_events(self, listener=None):
-        if listener is not None:
-            TAPManager.Instance.OnMoused -= listener
+        self.unregister_event(TAPManager.Instance.OnMoused, listener)
 
     def register_connection_events(self, listener=None):
-        if listener is not None:
-            TAPManager.Instance.OnTapConnected += listener
+        self.register_event(TAPManager.Instance.OnTapConnected, listener)
 
     def unregister_connection_events(self, listener=None):
-        if listener is not None:
-            TAPManager.Instance.OnTapConnected -= listener
+        self.unregister_event(TAPManager.Instance.OnTapConnected, listener)
 
     def register_disconnection_events(self, listener=None):
-        if listener is not None:
-            TAPManager.Instance.OnTapDisconnected += listener
+        self.register_event(TAPManager.Instance.OnTapDisconnected, listener)
 
     def unregister_disconnection_events(self, listener=None):
-        if listener is not None:
-            TAPManager.Instance.OnTapDisconnected -= listener
+        self.unregister_event(TAPManager.Instance.OnTapDisconnected, listener)
 
     def register_raw_data_events(self, listener=None):
-        if listener is not None:
-            TAPManager.Instance.OnRawSensorDataReceieved += listener
+        self.register_event(TAPManager.Instance.OnRawSensorDataReceieved, listener)
 
     def unregister_raw_data_events(self, listener=None):
-        if listener is not None:
-            TAPManager.Instance.OnRawSensorDataReceieved -= listener
+        self.unregister_event(TAPManager.Instance.OnRawSensorDataReceieved, listener)
 
     def register_air_gesture_events(self, listener=None):
-        if listener is not None:
-            TAPManager.Instance.OnAirGestured += listener
+        self.register_event(TAPManager.Instance.OnAirGestured, listener)
 
     def unregister_air_gesture_events(self, listener=None):
-        if listener is not None:
-            TAPManager.Instance.OnAirGestured -= listener
+        self.unregister_event(TAPManager.Instance.OnAirGestured, listener)
 
     def register_air_gesture_state_events(self, listener=None):
-        if listener is not None:
-            TAPManager.Instance.OnChangedAirGestureState += listener
+        self.register_event(TAPManager.Instance.OnChangedAirGestureState, listener)
 
     def unregister_air_gesture_state_events(self, listener=None):
-        if listener is not None:
-            TAPManager.Instance.OnChangedAirGestureState -= listener
+        self.unregister_event(TAPManager.Instance.OnChangedAirGestureState, listener)
 
-    def show_logs(self):
-        TAPManagerLog.Instance.OnLineLogged += print
+    def register_log_events(self, listener=print):
+        self.register_event(TAPManagerLog.Instance.OnLineLogged, listener)
 
-    def suppress_logs(self):
-        TAPManagerLog.Instance.OnLineLogged -= print
+    def unregister_log_events(self, listener=print):
+        self.unregister_event(TAPManagerLog.Instance.OnLineLogged, listener)
 
     def set_input_mode(self, mode:TapInputMode, tap_identifier=""):
         print("input mode: " + mode.get_name())


### PR DESCRIPTION
* Allow unregistering event listeners through TapWindowsSDK
* DRY up TapWindowsSDK event listener logic
* Abstract logging callback to allow log suppression or rerouting to callbacks other than `print`