### PR TITLE
Implement Python logging

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,3 @@
 [flake8]
 max-line-length = 120
+exclude = .git, __pycache__, .env*, build, dist, *.egg-info

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -1,36 +1,41 @@
 import asyncio
+import logging
 import time
 
 from tapsdk import TapInputMode, TapSDK, InputType, AirGestures
 
 
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
 def OnDisconnection(identifier):
-    print("Disconnected. ", identifier)
+    logger.info("Disconnected. %s", identifier)
 
 
 def OnConnection(identifier):
-    print("Connected. ", identifier)
+    logger.info("Connected. %s", identifier)
 
 
 def OnMouseModeChange(identifier, mouse_mode):
-    print(str(identifier) + " changed to mode " + str(mouse_mode))
+    logger.info("%s changed to mode %s", identifier, mouse_mode)
 
 
 def OnTapped(identifier, tapcode):
-    print(str(identifier) + " tapped " + str(tapcode))
+    logger.info("%s tapped %s", identifier, tapcode)
 
 
 def OnGesture(identifier, gesture):
-    print(str(identifier) + " gesture " + str(AirGestures(gesture)))
+    logger.info("%s gesture %s", identifier, AirGestures(gesture))
 
 
 def OnMoused(identifier, vx, vy, isMouse):
-    print(str(identifier) + " mouse movement: %d, %d, %d" % (vx, vy, isMouse))
+    logger.info("%s mouse movement: %d, %d, %d", identifier, vx, vy, isMouse)
 
 
 def OnRawData(identifier, packets):
     for m in packets:
-        print(f"{m['type']}, {time.time()}, {m['payload']}")
+        logger.info("%s, %s, %s", m['type'], time.time(), m['payload'])
 
 
 async def run(loop):
@@ -44,33 +49,33 @@ async def run(loop):
     client.register_mouse_events(OnMoused)
     client.register_air_gesture_state_events(OnMouseModeChange)
     await client.run()
-    print("Connected: {0}".format(client.client.is_connected))
+    logger.info("Connected: %s", client.client.is_connected)
 
-    print("Set Controller Mode for 5 seconds")
+    logger.info("Set Controller Mode for 5 seconds")
     await client.set_input_mode(TapInputMode("controller"))
     await asyncio.sleep(5)
 
-    print("Force Mouse Mode for 5 seconds")
+    logger.info("Force Mouse Mode for 5 seconds")
     await client.set_input_type(InputType.MOUSE)
     await asyncio.sleep(5)
 
-    print("Force keyboard Mode for 5 seconds")
+    logger.info("Force keyboard Mode for 5 seconds")
     await client.set_input_type(InputType.KEYBOARD)
     await asyncio.sleep(5)
 
-    print("Set auto Mode for 10 seconds")
+    logger.info("Set auto Mode for 10 seconds")
     await client.set_input_type(InputType.AUTO)
     await asyncio.sleep(10)
 
-    print("Set Text Mode for 10 seconds")
+    logger.info("Set Text Mode for 10 seconds")
     await client.set_input_mode(TapInputMode("text"))
     await asyncio.sleep(10)
 
-    print("Send Haptics")
+    logger.info("Send Haptics")
     await client.send_vibration_sequence([100, 200, 100, 200, 500])
     await asyncio.sleep(5)
 
-    print("Set Raw Mode for 5 seconds")
+    logger.info("Set Raw Mode for 5 seconds")
     await asyncio.sleep(2)
     await client.set_input_mode(TapInputMode("raw", sensitivity=[0, 0, 0]))
     await asyncio.sleep(5)

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -2,10 +2,10 @@ import asyncio
 import logging
 import time
 
-from tapsdk import TapInputMode, TapSDK, InputType, AirGestures
-
+from tapsdk import AirGestures, InputType, TapInputMode, TapSDK
 
 logging.basicConfig(level=logging.INFO)
+logging.getLogger("tapsdk").setLevel(logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 

--- a/tapsdk/inputmodes.py
+++ b/tapsdk/inputmodes.py
@@ -1,6 +1,8 @@
 import logging
 from .enumerations import InputType
 
+logger = logging.getLogger(__name__)
+
 
 class TapInputMode:
     def __init__(self, mode, sensitivity=[0, 0, 0]):
@@ -16,7 +18,7 @@ class TapInputMode:
             if mode == "raw":
                 self._register_sensitivity(sensitivity)
         else:
-            logging.warning("Invalid mode \"%s\". Set to \"text\"" % mode)
+            logger.warning("Invalid mode \"%s\". Set to \"text\"", mode)
             self.mode = "text"
 
     def _register_sensitivity(self, sensitivity):

--- a/tapsdk/tap.py
+++ b/tapsdk/tap.py
@@ -6,12 +6,11 @@ from typing import Callable
 
 from bleak import BleakClient, BleakScanner
 
-logger = logging.getLogger(__name__)
-
 from . import parsers
 from .enumerations import InputType, MouseModes
 from .inputmodes import TapInputMode, input_type_command
 
+logger = logging.getLogger(__name__)
 
 tap_service = 'c3ff0001-1d8b-40fd-a56f-c7bd5d0f3370'
 nus_service = '6e400001-b5a3-f393-e0a9-e50e24dcca9e'

--- a/tapsdk/tap.py
+++ b/tapsdk/tap.py
@@ -1,10 +1,12 @@
 import asyncio
+import logging
 import platform
 from asyncio.events import AbstractEventLoop
 from typing import Callable
 
 from bleak import BleakClient, BleakScanner
-from bleak import _logger as logger
+
+logger = logging.getLogger(__name__)
 
 from . import parsers
 from .enumerations import InputType, MouseModes
@@ -109,10 +111,11 @@ elif platform.system() == "Linux":
                 connected_bt_devices = btdevice_process.stdout.read().splitlines()
                 tap_devices = list(filter(lambda line: line.startswith("Tap"), connected_bt_devices))
                 for d in tap_devices:
-                    logger.info("Found tap device: {}".format(d))
+                    logger.info("Found tap device: %s", d)
                 if len(tap_devices) > 1:
-                    print("Found more than 1 Tap device:")
-                    [print(f"{i+1}. {d}") for i, d in enumerate(tap_devices)]
+                    logger.info("Found more than 1 Tap device:")
+                    for i, d in enumerate(tap_devices):
+                        logger.info("%s. %s", i + 1, d)
                     tap_devices = [tap_devices[int(input("Select the device number: ")) - 1]]
                 if len(tap_devices) == 0:
                     raise ValueError(
@@ -237,16 +240,16 @@ class TapSDK():
         devices = []
 
         async def detection_cb(device, adv_data):
-            print("detected ", device, adv_data)
+            logger.debug("detected %s %s", device, adv_data)
             if tap_service.lower() in adv_data.service_uuids:
                 if device.address not in [d.address for d in devices]:
                     devices.append(device)
-                    print("detected ", device, adv_data)
+                    logger.debug("detected %s %s", device, adv_data)
                     stop_event.set()
 
         connected = await self.client.connect_retrieved()
         if not connected:
-            print("Couldn't find connected Tap device. Scanning for Tap devices...")
+            logger.info("Couldn't find connected Tap device. Scanning for Tap devices...")
             async with BleakScanner(detection_callback=detection_cb) as _:
                 await stop_event.wait()
 


### PR DESCRIPTION
## Summary
- plug standard Python logging into Tap SDK modules
- replace print statements with logger calls
- update example to use logging

## Testing
- `pytest -q`
