### PR TITLE
Harden Windows BLE deps and publish release gates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,5 +58,21 @@ jobs:
           pip install build
       - name: Build package
         run: python -m build
+      - name: Check package metadata
+        run: |
+          pip install twine
+          twine check dist/*
+      - name: Smoke test built wheel
+        run: |
+          python -m venv /tmp/wheel-venv
+          /tmp/wheel-venv/bin/pip install --upgrade pip
+          /tmp/wheel-venv/bin/pip install dist/*.whl
+          /tmp/wheel-venv/bin/python -c "from tapsdk import TapSDK; from tapsdk.__version__ import __version__; print(__version__)"
+      - name: Smoke test built sdist
+        run: |
+          python -m venv /tmp/sdist-venv
+          /tmp/sdist-venv/bin/pip install --upgrade pip
+          /tmp/sdist-venv/bin/pip install dist/*.tar.gz
+          /tmp/sdist-venv/bin/python -c "from tapsdk import TapSDK"
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+# bleak version is platform-specific; see setup.py REQUIRED for exact pins.
 bleak
 setuptools

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,11 @@ REQUIRED = [
     # macOS reqs
     'bleak==0.12.1;platform_system=="Darwin"',
     # Windows reqs
-    'bleak;platform_system=="Windows"'
+    # bleak>=0.22.0 switched its Windows backend to PyWinRT and no longer
+    # depends on bleak-winrt, but tapsdk's Windows code still targets the
+    # bleak-winrt API (see #21), so it must be installed explicitly here.
+    'bleak==0.22.3;platform_system=="Windows"',
+    'bleak-winrt==1.2.0;platform_system=="Windows"',
 ]
 
 
@@ -40,6 +44,7 @@ setup(
     version=about["__version__"],
     description=DESCRIPTION,
     long_description=long_description,
+    long_description_content_type="text/markdown",
     author=AUTHOR,
     author_email=EMAIL,
     url=URL,

--- a/tapsdk/tap.py
+++ b/tapsdk/tap.py
@@ -25,10 +25,12 @@ if platform.system() == "Darwin":
     try:
         from bleak.backends.corebluetooth.CentralManagerDelegate import (
             CBUUID, CentralManagerDelegate)
-    except ImportError:
-        # The CoreBluetooth backend internals moved across bleak versions. Keep the
-        # module importable (e.g. for tests/tooling) and defer the failure to runtime.
-        CBUUID = CentralManagerDelegate = None
+    except ImportError as e:
+        raise ImportError(
+            "tapsdk requires bleak==0.12.1 on macOS; the installed bleak version "
+            "no longer exposes bleak.backends.corebluetooth.CentralManagerDelegate "
+            "at this import path. Reinstall with the pinned dependency from setup.py."
+        ) from e
 
     def string2uuid(uuid_str: str) -> CBUUID:
         """Convert a string to a uuid"""
@@ -64,13 +66,16 @@ elif platform.system() == "Windows":
                                                            BluetoothConnectionStatus, BluetoothCacheMode)
         from bleak_winrt.windows.devices.bluetooth.genericattributeprofile import GattSession, GattSessionStatus
         from bleak_winrt.windows.devices.enumeration import DeviceInformation, DeviceInformationKind
-    except ImportError:
-        # bleak_winrt ships only with bleak < 1.0; it is unavailable with bleak 3.x
-        # (see #21). Defer the failure to runtime so the module stays importable for
-        # tooling/tests on Windows while the Windows BLE path is still broken.
-        BluetoothLEDevice = BluetoothConnectionStatus = BluetoothCacheMode = None
-        GattSession = GattSessionStatus = None
-        DeviceInformation = DeviceInformationKind = None
+    except ImportError as e:
+        # bleak>=0.22.0 no longer depends on bleak_winrt (see #21), so it must be
+        # installed explicitly; setup.py pins bleak==0.22.3 + bleak-winrt==1.2.0
+        # for Windows. Fail fast if that pin was not honored, rather than
+        # silently disabling the Windows BLE backend at runtime.
+        raise ImportError(
+            "tapsdk requires bleak==0.22.3 and bleak-winrt==1.2.0 on Windows. "
+            "Reinstall with the pinned dependencies from setup.py, or see "
+            "https://github.com/TapWithUs/tap-python-sdk/issues/21."
+        ) from e
 
     async def get_connected_taps():
         # use the following device properties: Paired, Connected, Device Address

--- a/tests/test_cross_platform.py
+++ b/tests/test_cross_platform.py
@@ -1,4 +1,32 @@
+import platform
+
+
 def test_tapclient_importable():
     import tapsdk.tap as tap
 
     assert hasattr(tap, "TapClient")
+
+
+def test_platform_ble_backend_is_not_silently_disabled():
+    """Guard against optional BLE backend imports failing silently.
+
+    tapsdk.tap used to swallow ImportError for the platform-specific BLE
+    backend and fall back to `None` symbols, which let the module import
+    successfully while every BLE call would later crash with AttributeError.
+    This asserts the backend symbols used on the running platform were
+    actually imported.
+    """
+    import tapsdk.tap as tap
+
+    system = platform.system()
+    if system == "Darwin":
+        assert tap.CBUUID is not None
+        assert tap.CentralManagerDelegate is not None
+    elif system == "Windows":
+        assert tap.BluetoothLEDevice is not None
+        assert tap.BluetoothConnectionStatus is not None
+        assert tap.BluetoothCacheMode is not None
+        assert tap.GattSession is not None
+        assert tap.GattSessionStatus is not None
+        assert tap.DeviceInformation is not None
+        assert tap.DeviceInformationKind is not None


### PR DESCRIPTION
## Summary
- Pin Windows to `bleak==0.22.3` and explicit `bleak-winrt==1.2.0`, and fail fast with clear errors if platform BLE backends are missing instead of silently binding symbols to `None`.
- Strengthen cross-platform tests so CI catches silently disabled BLE backends before release.
- Add `twine check` plus wheel/sdist smoke tests to the publish workflow, and set `long_description_content_type` so PyPI metadata validates cleanly.

Follow-up to #34 after Bugbot review findings.

## Test plan
- [ ] Confirm CI matrix is green on Linux/macOS/Windows
- [ ] Confirm Windows install resolves `bleak==0.22.3` and `bleak-winrt==1.2.0`
- [ ] Confirm `tests/test_cross_platform.py` fails if WinRT/CoreBluetooth imports are missing
- [ ] Dry-run publish job steps locally: `python -m build`, `twine check dist/*`, install wheel/sdist in a clean venv and import `TapSDK`