### PR TITLE
Avoid TapSDK import in publish smoke tests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,17 +62,18 @@ jobs:
         run: |
           pip install twine
           twine check dist/*
+      # Import package/version only — avoid TapSDK/bleak, which needs bluetoothctl on Linux.
       - name: Smoke test built wheel
         run: |
           python -m venv /tmp/wheel-venv
           /tmp/wheel-venv/bin/pip install --upgrade pip
           /tmp/wheel-venv/bin/pip install dist/*.whl
-          /tmp/wheel-venv/bin/python -c "from tapsdk import TapSDK; from tapsdk.__version__ import __version__; print(__version__)"
+          /tmp/wheel-venv/bin/python -c "import tapsdk; from tapsdk.__version__ import __version__; print(__version__)"
       - name: Smoke test built sdist
         run: |
           python -m venv /tmp/sdist-venv
           /tmp/sdist-venv/bin/pip install --upgrade pip
           /tmp/sdist-venv/bin/pip install dist/*.tar.gz
-          /tmp/sdist-venv/bin/python -c "from tapsdk import TapSDK"
+          /tmp/sdist-venv/bin/python -c "import tapsdk; from tapsdk.__version__ import __version__; print(__version__)"
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
- Soften publish wheel/sdist smoke tests to `import tapsdk` + `__version__` instead of `from tapsdk import TapSDK`.
- Avoids bleak 0.6.4's import-time `bluetoothctl` check, which fails on GitHub Ubuntu runners and blocked the `v0.7.0` publish.

## Test plan
- [ ] Re-run Publish workflow by re-pushing `v0.7.0` after merge
- [ ] Confirm smoke test steps pass and PyPI upload proceeds